### PR TITLE
patch(error-en-login): arreglado un error de URLs

### DIFF
--- a/src/keycloak/services/user.service.ts
+++ b/src/keycloak/services/user.service.ts
@@ -46,7 +46,7 @@ export class KeycloakUserService {
     }
 
     if (response.headers.location) {
-      response.headers.location = response.headers.location.replace('http', 'https')
+      response.headers.location = response.headers.location.replace('http://', 'https://')
     }
 
     return [response, cookies]


### PR DESCRIPTION
Hay algunas URLs que estaban siendo reescritas de https:// a httpss://, esta nueva versión eliminará ese error.